### PR TITLE
Clarify the .min.gz size of VanJS, as most of the libraries are using…

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -124,7 +124,7 @@
     {
         "name": "VanJS",
         "repo_url": "https://github.com/vanjs-org/van",
-        "size": "1.3 KB",
+        "size": "1.3 KB, 0.8 KB .min.gz",
         "web_components": false,
         "cdn_url": "https://cdn.jsdelivr.net/gh/vanjs-org/van/public/van-0.12.2.min.js",
         "categories": ["ui"]

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -124,7 +124,7 @@
     {
         "name": "VanJS",
         "repo_url": "https://github.com/vanjs-org/van",
-        "size": "1.3 KB, 0.8 KB .min.gz",
+        "size": "0.8 KB",
         "web_components": false,
         "cdn_url": "https://cdn.jsdelivr.net/gh/vanjs-org/van/public/van-0.12.2.min.js",
         "categories": ["ui"]


### PR DESCRIPTION
… .min.gz