### PR TITLE
Add project Lithent

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -193,5 +193,13 @@
         "web_components": true,
         "cdn_url": "https://unpkg.com/lighterhtml?module",
         "categories": ["ui"]
+    },
+    {   
+        "name": "Lithent",
+        "repo_url": "https://github.com/superlucky84/lithent",
+        "size": "3 KB",
+        "web_components": false,
+        "cdn_url": "https://cdn.jsdelivr.net/npm/lithent/dist/lithent.umd.js",
+        "categories": ["ui"]
     }
 ]


### PR DESCRIPTION
## Add a new virtual DOM library

Just give me a spot in the back.

* github: https://github.com/superlucky84/lithent
* homepage: https://superlucky84.github.io/lithent/

Lithent were developed to make it easy to insert Virtual DOM component fragments into pages already drawn with SSR, and are intended to be used lightly in a variety of situations.