### PR TITLE
Update libraries.json - add reef library

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -199,7 +199,8 @@
         "repo_url": "https://github.com/cferdinandi/reef",
         "size": "~4.2 KB (1.6 KB gzip)",        
         "cdn_url": "https://cdn.jsdelivr.net/npm/reefjs@12/dist/reef.min.js",
-        "web_components": false,        
+        "web_components": false,
+        "ie11_compatible": false,
         "categories": ["ui"]        
     }
 ]

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -193,5 +193,13 @@
         "web_components": true,
         "cdn_url": "https://unpkg.com/lighterhtml?module",
         "categories": ["ui"]
+    },
+    {
+        "name": "reef",
+        "repo_url": "https://github.com/cferdinandi/reef",
+        "size": "~4.2 KB (1.6 KB gzip)",        
+        "cdn_url": "https://cdn.jsdelivr.net/npm/reefjs@12/dist/reef.min.js",
+        "web_components": false,        
+        "categories": ["ui"]        
     }
 ]


### PR DESCRIPTION
# A tiny utility library for building reactive state-based UI.

Reef is a simpler alternative to React, Vue, and other UI libraries. No build steps. No fancy syntax. Just vanilla JS and a few small utility functions.

## Features

* Weighs just 1.6kb minified and gzipped, with zero dependencies.
* Simple templating with JavaScript strings or template literals.
* Load it with a <script> element or ES module import—no command line or transpiling required (though you can if you want).
* Uses DOM diffing to update only the things that have changed.
* Automatically sanitizes HTML before rendering to help protect you from cross-site scripting (XSS) attacks.
* Write vanilla JS, and use a few small utility methods only when they’re needed.
*  Compatible with all modern browsers.

Make web development fun and simple again!