### PR TITLE
Add project tmpl-htm

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -198,6 +198,7 @@
         "name": "tmpl-htm",
         "repo_url": "https://github.com/superlucky84/tmpl-htm",
         "size": "1.9 KB",
+        "ie11_compatible": true,
         "web_components": false,
         "cdn_url": "https://cdn.jsdelivr.net/npm/tmpl-htm@1.0.1/dist/tmplHtm.umd.js",
         "categories": ["ui"]

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -198,7 +198,6 @@
         "name": "tmpl-htm",
         "repo_url": "https://github.com/superlucky84/tmpl-htm",
         "size": "1.9 KB",
-        "ie11_compatible": true,
         "web_components": false,
         "cdn_url": "https://cdn.jsdelivr.net/npm/tmpl-htm@1.0.1/dist/tmplHtm.umd.js",
         "categories": ["ui"]

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -193,5 +193,13 @@
         "web_components": true,
         "cdn_url": "https://unpkg.com/lighterhtml?module",
         "categories": ["ui"]
+    },
+    {   
+        "name": "tmpl-htm",
+        "repo_url": "https://github.com/superlucky84/tmpl-htm",
+        "size": "1.9 KB",
+        "web_components": false,
+        "cdn_url": "https://cdn.jsdelivr.net/npm/tmpl-htm@1.0.1/dist/tmplHtm.umd.js",
+        "categories": ["ui"]
     }
 ]


### PR DESCRIPTION
## Generate HTML elements using HTM ("Hyperscript Tagged Markup") or JSX.

*  just 1.9kb minified and gzipped
* Simple templating with template literals.
* Load it with a <script> element or ES module import
* Compatible with all modern browsers.