### PR TITLE
Tram-Lite: update gzipped size and cdn_url

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -165,9 +165,9 @@
     {
         "name": "Tram-Lite",
         "repo_url": "https://github.com/Tram-One/tram-lite",
-        "size": "10 KB",
+        "size": "1.3 KB",
         "web_components": true,
-        "cdn_url": "https://unpkg.com/tram-lite@2.4.0/src/tram-lite.js",
+        "cdn_url": "https://unpkg.com/tram-lite",
         "categories": ["ui"]
     },
     {   

--- a/data/libraries.json
+++ b/data/libraries.json
@@ -165,7 +165,7 @@
     {
         "name": "Tram-Lite",
         "repo_url": "https://github.com/Tram-One/tram-lite",
-        "size": "1.3 KB",
+        "size": "1.6 KB",
         "web_components": true,
         "cdn_url": "https://unpkg.com/tram-lite",
         "categories": ["ui"]


### PR DESCRIPTION
Reduced the listed size for Tram-Lite, and updated the cdn url to be a more generic pointer.

In part, this was a misunderstanding on my part about how assets would be natively gzipped (I didn't know this was a thing 😅), additionally, Tram-Lite now serves a minified asset (next to the default asset).

From testing locally (using the unpkg.com cdn), the size returned is 1.6 kB

![screenshot of a network chart, in the name column, it says tram-lite.min.js, in the size column it says 1.6 kB, in the time column it says 26ms](https://github.com/adamghill/unsuckjs.com/assets/326557/24ff1f10-b6d3-4297-80f5-23d30e512ab9)
